### PR TITLE
Correct ACM permissions check in viewer

### DIFF
--- a/packages/sdc_viewer/src/sdc_viewer/viewer_backend.py
+++ b/packages/sdc_viewer/src/sdc_viewer/viewer_backend.py
@@ -66,6 +66,13 @@ class SDCViewer:
 
     # Function to extract a select file
     def extract_document(self, file_id, dest_path):
+        # Check ACM permissions
+        if (
+            not self.acm.documents.get(file_id)
+            or self.current_user_level not in self.acm.documents[file_id]
+        ):
+            raise PermissionError(f"Access denied for file ID: {file_id}")
+        
         try:
             key = bytes.fromhex(self.key_library[file_id])
             enc_filepath = os.path.join(self.contents_dir, file_id)

--- a/tests/integration/test_viewer.py
+++ b/tests/integration/test_viewer.py
@@ -45,7 +45,8 @@ def test_viewer():
         viewer.extract_document("nonexistent", extractionoutputpath + "nonexistent")
 
     # Extracting a document that the user does not have permissions for should fail
-    assert not viewer.extract_document("text_normal_3.txt", extractionoutputpath + "text_normal_3.txt")
+    with pytest.raises(Exception):
+        viewer.extract_document("text_normal_3.txt", extractionoutputpath + "text_normal_3.txt")
 
     # Extracting a document that the user does have permissions for should succeed
     assert viewer.extract_document("text_normal_2.txt", extractionoutputpath + "text_normal_2.txt")

--- a/tests/integration/test_viewer.py
+++ b/tests/integration/test_viewer.py
@@ -48,6 +48,20 @@ def test_viewer():
     with pytest.raises(Exception):
         viewer.extract_document("text_normal_3.txt", extractionoutputpath + "text_normal_3.txt")
 
+    # The error for nonexistent documents and documents with insufficient permissions should be identical
+    try:
+        # Get the error message for a document that doesn't exist
+        viewer.extract_document("nonexistent_1", extractionoutputpath + "nonexistent_1")
+        assert False
+    except Exception as e1:
+        try:
+            # Get the error message for a document without permission to access
+            viewer.acm.add_document("nonexistent_1", ["admin"])
+            viewer.extract_document("nonexistent_1", extractionoutputpath + "nonexistent_1")
+            assert False
+        except Exception as e2:
+            assert str(e1) == str(e2), "Error message for trying to access a nonexistent document and a document with insufficient permission to access are different"
+
     # Extracting a document that the user does have permissions for should succeed
     assert viewer.extract_document("text_normal_2.txt", extractionoutputpath + "text_normal_2.txt")
 


### PR DESCRIPTION
Adds additional check for ACM permissions. Closes #19.

The tests were already adjusted to account for the change.